### PR TITLE
docs: proxy /openapi.json via Cloudflare Pages Function (GET/HEAD + E…

### DIFF
--- a/functions/openapi.json.ts
+++ b/functions/openapi.json.ts
@@ -1,0 +1,21 @@
+export const onRequest: PagesFunction = async (ctx) => {
+  const upstream = new URL("https://api.useportpulse.com/openapi.json");
+  upstream.search = new URL(ctx.request.url).search;
+
+  const fwd = new Headers();
+  const pass = (k: string) => { const v = ctx.request.headers.get(k); if (v) fwd.set(k, v); };
+  pass("if-none-match"); pass("if-modified-since"); pass("accept"); pass("user-agent");
+
+  const init: RequestInit = { method: ctx.request.method === "HEAD" ? "HEAD" : "GET", headers: fwd };
+  const u = await fetch(upstream.toString(), init);
+
+  const keep = ["content-type","cache-control","etag","last-modified","access-control-allow-origin","access-control-expose-headers"];
+  const out = new Headers();
+  for (const k of keep) { const v = u.headers.get(k); if (v) out.set(k, v); }
+  if (!out.has("access-control-allow-origin")) out.set("access-control-allow-origin","*");
+  if (!out.has("access-control-expose-headers")) out.set("access-control-expose-headers","ETag, Content-Length, Content-Type");
+  out.set("x-portpulse-proxy","pages-functions");
+
+  if (ctx.request.method === "HEAD") return new Response(null, { status: u.status, headers: out });
+  return new Response(u.body, { status: u.status, headers: out });
+};

--- a/src/pages/openapi.tsx
+++ b/src/pages/openapi.tsx
@@ -7,7 +7,7 @@ export default function OpenAPIPage() {
     <Layout title="API Reference" description="PortPulse OpenAPI reference">
       <div style={{ minHeight: 'calc(100vh - 120px)' }}>
         <RedocStandalone
-          specUrl="https://api.useportpulse.com/openapi.json"
+          specUrl="/openapi.json"
           options={{
             hideDownloadButton: false,
             expandResponses: '200,201',

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,1 +1,0 @@
-/openapi.json*  https://api.useportpulse.com/openapi.json  200


### PR DESCRIPTION
…Tag passthrough); point Redoc to /openapi.json; drop redirects/static schema
Summary
- Use Cloudflare Pages Function to serve /openapi.json (GET/HEAD).
- Pass through ETag/Cache-Control/Content-Type headers for 304 reuse.
- Redoc specUrl -> /openapi.json.
- Remove static openapi.json & external 200 redirect.

Why
- Keep docs and API schema 1:1 with strong ETag.
- Avoid stale static schema & CDN “age” drift.

Acceptance
- HEAD/GET to https://docs.useportpulse.com/openapi.json returns JSON + ETag.
- Path set matches API; diff = empty.
- 200 → 304 works via If-None-Match.
- Redoc renders OK at /openapi.